### PR TITLE
fix: tutorial 2 missing predicate

### DIFF
--- a/solutions/tutorial2.md
+++ b/solutions/tutorial2.md
@@ -42,13 +42,14 @@ Define a predicate that is the opposite of Intersecting that takes in two sets, 
 ```typescript
 type Set
 predicate Intersecting : Set s1 * Set s2
+predicate Not : Prop p1
 ```
 
 `.sub`
 ```
 Set A
 Set B
-NotIntersecting(A, B)
+Not(Intersecting(A, B))
 ```
 
 `.sty`


### PR DESCRIPTION
It seems the solution is wrong. I get `Type Not (at line 9, column 1 of Substance program) does not exist.`. The fix here is copied from the set theory example DSL.